### PR TITLE
for speeding up __delete_noise_nodes

### DIFF
--- a/soinn/soinn.py
+++ b/soinn/soinn.py
@@ -98,7 +98,7 @@ class Soinn(object):
                 pal_indexes = []
                 for k in pals.keys():
                     pal_indexes.append(k[1])
-                sq_dists = np.sum((self.nodes[pal_indexes] - np.stack([self.nodes[i] for j in range(len(pal_indexes))]))**2, 1)
+                sq_dists = np.sum((self.nodes[pal_indexes] - np.array([self.nodes[i] * len(pal_indexes)]))**2, 1)
                 sim_thresholds.append(np.max(sq_dists))
         return sim_thresholds
 
@@ -144,7 +144,31 @@ class Soinn(object):
         self.nodes = np.delete(self.nodes, indexes, 0)
         remained_indexes = list(set([i for i in range(n)]) - set(indexes))
         self.winning_times = [self.winning_times[i] for i in remained_indexes]
-        self.adjacent_mat = self.adjacent_mat[np.ix_(remained_indexes, remained_indexes)]
+        #old_ver_adjacent_mat = self.adjacent_mat[np.ix_(remained_indexes, remained_indexes)]
+        self.__update_adjacent_mat(indexes, n, len(remained_indexes))
+        #assert (old_ver_adjacent_mat.toarray() == self.adjacent_mat.toarray()).all()
+
+    def __update_adjacent_mat(self, indexes, prev_n, next_n):
+        while indexes:
+            next_adjacent_mat = dok_matrix((prev_n, prev_n))
+            for key1, key2 in self.adjacent_mat.keys():
+                if key1 == indexes[0] or key2 == indexes[0]:
+                    continue
+                if key1 > indexes[0]:
+                    new_key1 = key1 - 1
+                else:
+                    new_key1 = key1
+                if key2 > indexes[0]:
+                    new_key2 = key2 - 1
+                else:
+                    new_key2 = key2
+                #Because dok_matrix.__getitem__ is slow,
+                #access as dictionary.
+                next_adjacent_mat[new_key1, new_key2] = super(dok_matrix, self.adjacent_mat).__getitem__((key1, key2))
+            self.adjacent_mat = next_adjacent_mat.copy()
+            indexes = [i-1 for i in indexes]
+            indexes.pop(0)
+        self.adjacent_mat.resize((next_n, next_n))
 
     def __delete_noise_nodes(self):
         n = len(self.winning_times)
@@ -152,4 +176,5 @@ class Soinn(object):
         for i in range(n):
             if len(self.adjacent_mat[i, :]) < self.min_degree:
                 noise_indexes.append(i)
-        self.__delete_nodes(noise_indexes)
+        if noise_indexes:
+            self.__delete_nodes(noise_indexes)

--- a/soinn/soinn.py
+++ b/soinn/soinn.py
@@ -144,9 +144,7 @@ class Soinn(object):
         self.nodes = np.delete(self.nodes, indexes, 0)
         remained_indexes = list(set([i for i in range(n)]) - set(indexes))
         self.winning_times = [self.winning_times[i] for i in remained_indexes]
-        #old_ver_adjacent_mat = self.adjacent_mat[np.ix_(remained_indexes, remained_indexes)]
         self.__update_adjacent_mat(indexes, n, len(remained_indexes))
-        #assert (old_ver_adjacent_mat.toarray() == self.adjacent_mat.toarray()).all()
 
     def __update_adjacent_mat(self, indexes, prev_n, next_n):
         while indexes:

--- a/test/test_soinn.py
+++ b/test/test_soinn.py
@@ -137,6 +137,21 @@ class TestSoinn(unittest.TestCase):
         expected = [[0, 1, 1], [1, 0, 0], [1, 0, 0]]
         np.testing.assert_array_equal(self.soinn.adjacent_mat.toarray(), expected)
 
+    def test_update_adjacent_mat(self):
+        self.soinn.adjacent_mat[0, 1] = 1
+        self.soinn.adjacent_mat[1, 0] = 1
+        self.soinn.adjacent_mat[0, 2] = 2
+        self.soinn.adjacent_mat[2, 0] = 2
+        self.soinn.adjacent_mat[2, 3] = 3
+        self.soinn.adjacent_mat[3, 2] = 3
+
+        indexes = [1]
+        expected1 = self.soinn.adjacent_mat[np.ix_([0, 2, 3], [0, 2, 3])]
+        self.soinn._Soinn__update_adjacent_mat(indexes, 4, 3)
+        expected2 = [[0, 2, 0], [2, 0, 3], [0, 3, 0]]
+        np.testing.assert_array_equal(self.soinn.adjacent_mat.toarray(), expected1.toarray())
+        np.testing.assert_array_equal(self.soinn.adjacent_mat.toarray(), expected2)
+
     def test_find_nearest_nodes(self):
         signal = np.array([-1, 0])
         indexes, sq_dists = self.soinn._Soinn__find_nearest_nodes(1, signal)


### PR DESCRIPTION
たびたびすいません。高速化の必要がなければ無視してください。可読性は犠牲になっているので。。
一応こういうアイデアがあるんだよという気持ちで投げときます。
5000個のMNISTを食わせて3倍強高速です。

まず、
if noise_indexes:
            self.**delete_nodes(noise_indexes)
とすることで、不必要にself.__delete_nodesをコールするのを避けます。
また、
self.adjacent_mat = self.adjacent_mat[np.ix_(remained_indexes, remained_indexes)]
をやめて、
for key1, key2 in self.adjacent_mat.keys():
とべた書きして
next_adjacent_mat[new_key1, new_key2] = super(dok_matrix, self.adjacent_mat).__getitem**((key1, key2))

とすることで、dok_matrix[key1, key2]をコールしないようにして高速化しました。
dok_matrix.**getitem**は毎度内部的にdok_matrixのコピーを作って返してるので、遅いようです。
親クラスのディクショナリとしてアイテムにアクセスすると速くなります。

旧バージョンのadjacent_matとの同一性は147行目と149行目のコメントアウトを外すことで確認できます。
